### PR TITLE
feat(ios): set lang via JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,42 @@ cordova.epos2.getPrinterStatus()
   });
 ```
 
+### Set the printer language
+
+Let the language of the printer or text before printing. `EPOS2_MODEL_ANK` and `EPOS2_LANG_EN` are default.
+
+Available languages for `lang` (model language) are:
+
+* EPOS2_MODEL_ANK,
+* EPOS2_MODEL_CHINESE
+* EPOS2_MODEL_TAIWANAN
+* EPOS2_MODEL_KOREAN
+* EPOS2_MODEL_THAI
+* EPOS2_MODEL_SOUTHASIA
+
+For `textLang`:
+
+* EPOS2_LANG_EN
+* EPOS2_LANG_JA
+* EPOS2_LANG_ZH_CN
+* EPOS2_LANG_ZH_TW
+* EPOS2_LANG_KO
+* EPOS2_LANG_TH
+* EPOS2_LANG_VI
+* EPOS2_LANG_MULTI
+* EPOS2_PARAM_DEFAULT
+
+```
+cordova.epos2.setLang(lang, textLang)
+  .then(function(status) {
+    // status=true if language was set
+    console.log(status);
+  })
+  .catch(function(error) {
+    // error callback
+  });
+```
+
 ### Printing
 
 #### .print(stringData, successCallback, errorCallback)

--- a/src/ios/epos2Plugin.h
+++ b/src/ios/epos2Plugin.h
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) NSString* discoverCallbackId;
 
 // The hooks for our plugin commands
+- (void)setLang:(CDVInvokedUrlCommand *)command;
 - (void)startDiscover:(CDVInvokedUrlCommand *)command;
 - (void)stopDiscover:(CDVInvokedUrlCommand *)command;
 - (void)connectPrinter:(CDVInvokedUrlCommand *)command;

--- a/src/ios/epos2Plugin.m
+++ b/src/ios/epos2Plugin.m
@@ -3,6 +3,8 @@
 #import <Cordova/CDVAvailability.h>
 
 static NSDictionary *printerTypeMap;
+static NSDictionary *langMap;
+static NSDictionary *textLangMap;
 
 @interface epos2Plugin()<Epos2DiscoveryDelegate, Epos2PtrReceiveDelegate>
 @end
@@ -16,8 +18,8 @@ static NSDictionary *printerTypeMap;
     printerStatus = nil;
     printerConnected = NO;
     printerSeries = EPOS2_TM_P20;
-    lang = EPOS2_MODEL_TAIWAN;
-    textLang = EPOS2_LANG_ZH_TW;
+    lang = EPOS2_MODEL_ANK;
+    textLang = EPOS2_LANG_EN;
 
     printerTypeMap = @{
         @"TM-M10":    [NSNumber numberWithInt:EPOS2_TM_M10],
@@ -41,6 +43,45 @@ static NSDictionary *printerTypeMap;
         @"TM-L90":    [NSNumber numberWithInt:EPOS2_TM_L90],
         @"TM-H6000":  [NSNumber numberWithInt:EPOS2_TM_H6000]
     };
+    
+    langMap = @{
+        @"EPOS2_MODEL_ANK":    [NSNumber numberWithInt:EPOS2_MODEL_ANK],
+        @"EPOS2_MODEL_CHINESE":    [NSNumber numberWithInt:EPOS2_MODEL_CHINESE],
+        @"EPOS2_MODEL_TAIWAN":    [NSNumber numberWithInt:EPOS2_MODEL_TAIWAN],
+        @"EPOS2_MODEL_KOREAN":    [NSNumber numberWithInt:EPOS2_MODEL_KOREAN],
+        @"EPOS2_MODEL_THAI":  [NSNumber numberWithInt:EPOS2_MODEL_THAI],
+        @"EPOS2_MODEL_SOUTHASIA":  [NSNumber numberWithInt:EPOS2_MODEL_SOUTHASIA]
+    };
+    
+    textLangMap = @{
+        @"EPOS2_LANG_EN":    [NSNumber numberWithInt:EPOS2_LANG_EN],
+        @"EPOS2_LANG_JA":    [NSNumber numberWithInt:EPOS2_LANG_JA],
+        @"EPOS2_LANG_ZH_CN":    [NSNumber numberWithInt:EPOS2_LANG_ZH_CN],
+        @"EPOS2_LANG_ZH_TW":    [NSNumber numberWithInt:EPOS2_LANG_ZH_TW],
+        @"EPOS2_LANG_KO":    [NSNumber numberWithInt:EPOS2_LANG_KO],
+        @"EPOS2_LANG_TH":    [NSNumber numberWithInt:EPOS2_LANG_TH],
+        @"EPOS2_LANG_VI":    [NSNumber numberWithInt:EPOS2_LANG_VI],
+        @"EPOS2_LANG_MULTI":    [NSNumber numberWithInt:EPOS2_LANG_MULTI],
+        @"EPOS2_PARAM_DEFAULT":    [NSNumber numberWithInt:EPOS2_PARAM_DEFAULT]
+    };
+}
+
+-(void)setLang:(CDVInvokedUrlCommand *)command
+{
+    if ([command.arguments count] > 1) {
+        NSString *arg = [command.arguments objectAtIndex:1];
+        NSNumber *match = [textLangMap objectForKey:arg];
+        self->textLang = [match intValue];
+    }
+    if ([command.arguments count] > 0) {
+        NSString *arg = [command.arguments objectAtIndex:0];
+        NSNumber *match = [langMap objectForKey:arg];
+        self->lang = [match intValue];
+    }
+    
+    CDVPluginResult *cordovaResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES];
+    [self.commandDelegate sendPluginResult:cordovaResult callbackId:command.callbackId];
+
 }
 
 - (void)startDiscover:(CDVInvokedUrlCommand *)command
@@ -295,26 +336,26 @@ static NSDictionary *printerTypeMap;
         int result = EPOS2_SUCCESS;
         CDVPluginResult *cordovaResult;
         
-        result = [printer addTextFont:textFont];
+        result = [self->printer addTextFont:textFont];
 
         if (result == EPOS2_SUCCESS) {
-            result = [printer addTextLang:textLang];
+            result = [self->printer addTextLang:self->textLang];
         }       
 
         if (result == EPOS2_SUCCESS) {
-            result = [printer addTextSize:textSize height:textSize];
+            result = [self->printer addTextSize:textSize height:textSize];
         }
         
         if (result == EPOS2_SUCCESS) {
-            result = [printer addTextAlign:textAlign];
+            result = [self->printer addTextAlign:textAlign];
         }
         
         if (result == EPOS2_SUCCESS) {
             for (NSString *data in printData) {
                 if ([data isEqualToString:@"\n"]) {
-                    result = [printer addFeedLine:1];
+                    result = [self->printer addFeedLine:1];
                 } else {
-                    result = [printer addText:data];
+                    result = [self->printer addText:data];
                 }
                 
                 if (result != EPOS2_SUCCESS) {

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -73,6 +73,24 @@ function execDiscoverCommand(successCallback, errorCallback) {
  */
 var epos2 = {
   /**
+   * Set language for printer
+   *
+   * @param {String} lang
+   * @param {String} textLang
+   * @return {Promise}
+   */
+   setLang: function(lang, textLang) {
+    var args = [];
+    if (lang && typeof lang === "string") {
+      args.push(lang);
+    }
+    if (textLang && typeof textLang === "string") {
+      args.push(textLang);
+    }
+    return _exec("setLang", args, arguments);
+  },
+
+  /**
    * Start device discovery
    *
    * This will trigger the successCallback function for every


### PR DESCRIPTION
This PR allows plugin users to set the language at runtime via JavaScript. The default is now  `EPOS2_MODEL_ANK` and `EPOS2_LANG_EN` like the Epson SDK. So this would be a breaking change.

But this could be changed to the old default.

Closes #3