### PR TITLE
feat(ios): refactor barcode printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,55 @@ cordova.epos2.printText(stringData, 0, 1, 2, false)
   });
 ```
 
+#### .printBarCode(data, type, hriPosition,hriFont,Bwidth,Bheight,terminate)
+Print different types of barcodes. **Please refer to the Epson SDK documentation for correctly encoding the data**.
+
+Types:
+
+* EPOS2_BARCODE_UPC_A
+* EPOS2_BARCODE_UPC_E
+* EPOS2_BARCODE_EAN133
+* EPOS2_BARCODE_JAN133
+* EPOS2_BARCODE_EAN8
+* EPOS2_BARCODE_JAN8,
+* EPOS2_BARCODE_CODE39
+* EPOS2_BARCODE_ITF
+* EPOS2_BARCODE_CODABAR
+* EPOS2_BARCODE_CODE93
+* EPOS2_BARCODE_CODE128
+* EPOS2_BARCODE_GS1_128
+* EPOS2_BARCODE_GS1_DATABAR_OMNIDIRECTIONAL
+* EPOS2_BARCODE_GS1_DATABAR_TRUNCATED
+* EPOS2_BARCODE_GS1_DATABAR_LIMITED
+* EPOS2_BARCODE_GS1_DATABAR_EXPANDED
+
+
+Function parameters:
+* @param {String} Barcode Data String, Encode Data or Specify start character 
+* @param {String} Type Type of barcode
+* @param {Number} Specifies the HRI position.(0 - 3) 0:No print 1:above 2:below 3:both
+* @param {Number} Specifies the HRI font. (0 - 4) 
+* @param {Number} Specifies the width of a single module in dots. (2-6)
+* @param {Number} Specifies the height of the barcode in dots. (1 - 255)
+* @param {Boolean} [terminate=false] Send additional line feeds an a "cut" command to complete the print
+* @return {Promise} resolving on success, rejecting on error
+
+Example
+
+```
+cordova.epos2.printBarCode("123456789011", "EPOS2_BARCODE_EAN13", 0,0,2,70, true)
+.then(res => console.debug(res))
+.catch(e => console.error(e))
+```
+
+#### .printBarCode128(data, type, hriPosition,hriFont,Bwidth,Bheight,terminate)
+
+Helper function to print barcode 128 CODEB
+
+```
+cordova.epos2.printBarCode128("11111", 0,0,2,70, true).then(res => console.debug(res)).catch(e => console.error(e))
+```
+
 #### .printImage(data, printMode, halfTone, terminate)
 Send image data as data-url to the connected printer.
 

--- a/src/ios/epos2Plugin.m
+++ b/src/ios/epos2Plugin.m
@@ -3,6 +3,7 @@
 #import <Cordova/CDVAvailability.h>
 
 static NSDictionary *printerTypeMap;
+static NSDictionary *barcodeTypeMap;
 
 @interface epos2Plugin()<Epos2DiscoveryDelegate, Epos2PtrReceiveDelegate>
 @end
@@ -40,6 +41,25 @@ static NSDictionary *printerTypeMap;
         @"TM-U330":   [NSNumber numberWithInt:EPOS2_TM_U330],
         @"TM-L90":    [NSNumber numberWithInt:EPOS2_TM_L90],
         @"TM-H6000":  [NSNumber numberWithInt:EPOS2_TM_H6000]
+    };
+    
+    barcodeTypeMap = @{
+        @"EPOS2_BARCODE_UPC_A":    [NSNumber numberWithInt:EPOS2_BARCODE_UPC_A],
+        @"EPOS2_BARCODE_UPC_E":    [NSNumber numberWithInt:EPOS2_BARCODE_UPC_E],
+        @"EPOS2_BARCODE_EAN13":    [NSNumber numberWithInt:EPOS2_BARCODE_EAN13],
+        @"EPOS2_BARCODE_JAN13":    [NSNumber numberWithInt:EPOS2_BARCODE_JAN13],
+        @"EPOS2_BARCODE_EAN8":  [NSNumber numberWithInt:EPOS2_BARCODE_EAN8],
+        @"EPOS2_BARCODE_JAN8":    [NSNumber numberWithInt:EPOS2_BARCODE_JAN8],
+        @"EPOS2_BARCODE_CODE39":    [NSNumber numberWithInt:EPOS2_BARCODE_CODE39],
+        @"EPOS2_BARCODE_ITF":    [NSNumber numberWithInt:EPOS2_BARCODE_ITF],
+        @"EPOS2_BARCODE_CODABAR":    [NSNumber numberWithInt:EPOS2_BARCODE_CODABAR],
+        @"EPOS2_BARCODE_CODE93":    [NSNumber numberWithInt:EPOS2_BARCODE_CODE93],
+        @"EPOS2_BARCODE_CODE128":    [NSNumber numberWithInt:EPOS2_BARCODE_CODE128],
+        @"EPOS2_BARCODE_GS1_128":    [NSNumber numberWithInt:EPOS2_BARCODE_GS1_128],
+        @"EPOS2_BARCODE_GS1_DATABAR_OMNIDIRECTIONAL":  [NSNumber numberWithInt:EPOS2_BARCODE_GS1_DATABAR_OMNIDIRECTIONAL],
+        @"EPOS2_BARCODE_GS1_DATABAR_TRUNCATED":    [NSNumber numberWithInt:EPOS2_BARCODE_GS1_DATABAR_TRUNCATED],
+        @"EPOS2_BARCODE_GS1_DATABAR_LIMITED":  [NSNumber numberWithInt:EPOS2_BARCODE_GS1_DATABAR_LIMITED],
+        @"EPOS2_BARCODE_GS1_DATABAR_EXPANDED":   [NSNumber numberWithInt:EPOS2_BARCODE_GS1_DATABAR_EXPANDED]
     };
 }
 
@@ -388,27 +408,28 @@ static NSDictionary *printerTypeMap;
     }];
 }
 
-- (void)printBarCode128:(CDVInvokedUrlCommand *)command
+- (void)printBarCode:(CDVInvokedUrlCommand *)command
 {
     // read command arguments
     NSString *data = [command.arguments objectAtIndex:0];
-    int bType = EPOS2_BARCODE_CODE128;
+    NSString *type = [command.arguments objectAtIndex:1];
+    NSNumber *bType = [barcodeTypeMap objectForKey:type];
     int hriPosition = 0;
     int hriFont = 0;
     long bWidth = 2;
     long bHeight = 70;    
     
-    if ([command.arguments count] > 1) {
-        hriPosition = ((NSNumber *)[command.arguments objectAtIndex:1]).intValue;
-    }
     if ([command.arguments count] > 2) {
-        hriFont = ((NSNumber *)[command.arguments objectAtIndex:2]).intValue;
+        hriPosition = ((NSNumber *)[command.arguments objectAtIndex:2]).intValue;
     }
     if ([command.arguments count] > 3) {
-        bWidth = ((NSNumber *)[command.arguments objectAtIndex:3]).intValue;
+        hriFont = ((NSNumber *)[command.arguments objectAtIndex:3]).intValue;
     }
     if ([command.arguments count] > 4) {
-        bHeight = ((NSNumber *)[command.arguments objectAtIndex:4]).intValue;
+        bWidth = ((NSNumber *)[command.arguments objectAtIndex:4]).intValue;
+    }
+    if ([command.arguments count] > 5) {
+        bHeight = ((NSNumber *)[command.arguments objectAtIndex:5]).intValue;
     }
 
     // (re-)connect printer with stored information
@@ -424,8 +445,8 @@ static NSDictionary *printerTypeMap;
         int result = EPOS2_SUCCESS;
         CDVPluginResult *cordovaResult;
         
-        result = [printer addBarcode:data
-                                type:bType
+        result = [self->printer addBarcode:data
+                                type:bType.intValue
                                 hri:hriPosition
                                 font:hriFont
                                 width:bWidth

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -254,8 +254,38 @@ var epos2 = {
       });
   },
 
-  /**
+   /**
    * Send Barcode data to the connected printer
+   *
+   * Set `terminate` to True in order to complete the print job.
+   *
+   * @param {String} Barcode Data String 
+   * @param {String} Type Type of barcode
+   * @param {Number} Specifies the HRI position.(0 - 3) 0:No print 1:above 2:below 3:both
+   * @param {Number} Specifies the HRI font. (0 - 4) 
+   * @param {Number} Specifies the width of a single module in dots. (2-6)
+   * @param {Number} Specifies the height of the barcode in dots. (1 - 255)
+   * @param {Boolean} [terminate=false] Send additional line feeds an a "cut" command to complete the print
+   * @return {Promise} resolving on success, rejecting on error
+   */
+    printBarCode: function(
+      data,
+      type,
+      hriPosition,
+      hriFont,
+      Bwidth,
+      Bheight,
+      terminate,
+    ) {
+      var data = data;
+      return _exec("printBarCode", [data, type, , hriPosition || 0, hriFont || 0 , Bwidth || 2, Bheight || 70], arguments)
+        .then(function(result) {
+          return terminate ? _exec("sendData", [], []) : result;
+        });
+    },
+
+  /**
+   * Send Barcode128 data to the connected printer
    *
    * Set `terminate` to True in order to complete the print job.
    *
@@ -265,8 +295,6 @@ var epos2 = {
    * @param {Number} Specifies the width of a single module in dots. (2-6)
    * @param {Number} Specifies the height of the barcode in dots. (1 - 255)
    * @param {Boolean} [terminate=false] Send additional line feeds an a "cut" command to complete the print
-   * @param {Function} [successCallback]
-   * @param {Function} [errorCallback]
    * @return {Promise} resolving on success, rejecting on error
    */
   printBarCode128: function(
@@ -276,25 +304,9 @@ var epos2 = {
     Bwidth,
     Bheight,
     terminate,
-    successCallback,
-    errorCallback
   ) {
     var data = "{B" + data;
-    return _exec("printBarCode128", [data , hriPosition || 0, hriFont || 0 , Bwidth || 2, Bheight || 70], arguments)
-      .then(function(result) {
-        return terminate ? _exec("sendData", [], []) : result;
-      })
-      .then(function(result) {
-        if (typeof successCallback === "function") {
-          successCallback(result);
-        }
-      })
-      .catch(function(err) {
-        if (typeof errorCallback === "function") {
-          errorCallback(err);
-        }
-        throw err;
-      });
+    return this.printBarCode(data, "EPOS2_BARCODE_CODE128", hriPosition, hriFont, Bwidth, Bheight, terminate);
   },
 
   /**


### PR DESCRIPTION
The plugin now has a function `printBarcode` to print all supported types. The existing function was refactored to to use the new function. The callbacks have been removed as the functions return promises.